### PR TITLE
Made "backend" more convenient and improved design of the page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -379,6 +379,13 @@ p + h3 {
   width: auto;
   height: auto;
 }
+@media (min-width: 750px) {
+  img.image--full {
+    width: calc(var(--6-cols) - var(--grid-gutter) * 2);
+    border-radius: 30px;
+    margin: 40px auto;
+  }
+}
 
 .sponsors {
   margin-bottom: 2em;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -350,6 +350,12 @@ p + h3 {
   right: 0;
   display: flex;
   justify-content: center;
+  margin: 0 auto;
+}
+@media (min-width: 750px) {
+  .screenshots_container {
+    width: 95%;
+  }
 }
 .screenshots_inner {
   max-width: 100%;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -290,6 +290,10 @@ a:hover {
   margin: 0 auto;
 }
 
+.infobox_entry p.products {
+  width: var(--6-cols);
+}
+
 hr {
   border: none;
   margin: 3rem 0;

--- a/content/_index.md
+++ b/content/_index.md
@@ -41,94 +41,22 @@ Ist ein durch evcc unterstütztes Elektrofahrzeug eingerichtet, kann dessen mome
 Und noch etwas kann evcc: Ist ein unterstützter Batteriespeicher vorhanden, wird auch dessen Ladezustand gesteuert und mit Sonnenstrom versorgt.
 
 {{< infobox title="Unterstützte und getestete Komponenten" >}}
-{{< infobox-entry title="Wallboxen & Steckdosen" img="img/evcc-illu-wallbox.svg" >}}
-ABL eMHx
-• Alfen NG9xx
-• DaheimLaden Wallbox
-• cFos PowerBrain
-• Easee Home
-• EVSE-Wifi
-• go-eCharger
-• Heidelberg Energy Control
-• i-CHARGE CION
-• KEBA KeContact P30
-• Mennekes Amtron Xtra
-• Porsche Mobile Charger Connect
-• NRGKick
-• OpenWB
-• Phoenix Contact
-• TinkerForge WARP Charger
-• Simple EVSE
-• smartWB
-• Wallbe
-• SENEC.Wallbox pro
+  {{< infobox-entry title="Wallboxen & Steckdosen" img="img/evcc-illu-wallbox.svg" >}}
+    {{< infobox-content group="wallboxes">}}
+    {{< infobox-content group="smart_plugs">}}
+  {{< /infobox-entry >}}
 
-AVM FritzDECT
-• Shelly
-• Tasmota
-• TP-LINK Smart Plug
-{{< /infobox-entry >}}
-{{< infobox-entry title="Energiemesstechnik" img="img/evcc-illu-energiemessung.svg" >}}
-ABB
-• Bernecker Engineering
-• DDM
-• DZG
-• Discovergy
-• Eastron SDM
-• Inepro
-• KOSTAL Smart Energy Meter
-• ORNO
-• Phoenix Contact
-• PowerDog
-• Powerfox PowerOpti
-• SBC
-• SMA Sunny Home Manager & Energy Meter
-• Schneider Electric
-• SolarEdge
-• SolarLog
-• SunSpec-kompatibel
-• vzlogger
-{{< /infobox-entry >}}
-{{< infobox-entry title="Wechselrichter & Speichersysteme" img="img/evcc-illu-wechselrichter.svg" >}}
-E3DC
-• Fronius
-• Huawei
-• Kaco
-• KOSTAL
-• LG ESS
-• RCT Power
-• SENEC.Home
-• SMA
-• SolarEdge
-• sonnen
-• SunSpec-kompatibel
-• Tesla PowerWall
-• VARTA Energiespeicher
-{{< /infobox-entry >}}
-{{< infobox-entry title="Fahrzeuge" img="img/evcc-illu-fahrzeuge.svg" >}}
-Audi
-• BMW
-• Citroën
-• DS Automobiles
-• Fiat
-• Ford
-• Hyundai
-• Kia
-• Mini
-• Nissan
-• NIU (E-Scooter)
-• Opel
-• OVMS
-• Peugeot
-• Porsche
-• Renault
-• Seat
-• ŠKODA
-• Tesla
-• Tronity
-• Volkswagen
-• Volvo
-{{< /infobox-entry >}}
+  {{< infobox-entry title="Energiemesstechnik" img="img/evcc-illu-energiemessung.svg" >}}
+    {{< infobox-content group="meters">}}
+  {{< /infobox-entry >}}
+
+  {{< infobox-entry title="Wechselrichter & Speichersysteme" img="img/evcc-illu-wechselrichter.svg" >}}
+    {{< infobox-content group="systems">}}
+  {{< /infobox-entry >}}
+
+  {{< infobox-entry title="Fahrzeuge" img="img/evcc-illu-fahrzeuge.svg" >}}
+    {{< infobox-content group="vehicles">}}
+  {{< /infobox-entry >}}
 {{< /infobox >}}
 
 evcc setzt bei der Anbindung der Komponenten auf weit verbreitete Schnittstellen und Protokolle, wie z.B. Modbus, SunSpec, HTTP, JSON, REST sowie MQTT.

--- a/data/products.json
+++ b/data/products.json
@@ -1,0 +1,22 @@
+{
+    "wallboxes": {
+        "name": "wallboxes",
+        "values": ["ABL eMHx", "Alfen NG9xx", "DaheimLaden Wallbox", "cFos PowerBrain", "Easee Home", "EVSE-Wifi", "go-eCharger", "Heidelberg Energy Control", "i-CHARGE CION", "KEBA KeContact P30", "Mennekes Amtron Xtra", "Porsche Mobile Charger Connect", "NRGKick", "OpenWB", "Phoenix Contact", "TinkerForge WARP Charger", "Simple EVSE", "smartWB", "Wallbe", "SENEC.Wallbox pro"]
+    },
+    "smart_plugs": {
+        "name": "smart_plugs",
+        "values": ["AVM FritzDECT", "Shelly", "Tasmota", "TP-LINK Smart Plug"]
+    },
+    "meters": {
+        "name": "meters",
+        "values": ["ABB", "Bernecker Engineering", "DDM", "DZG", "Discovergy", "Eastron SDM", "Inepro", "KOSTAL Smart Energy Meter", "ORNO", "Phoenix Contact", "PowerDog", "Powerfox PowerOpti", "SBC", "SMA Sunny Home Manager & Energy Meter", "Schneider Electric", "SolarEdge", "SolarLog", "SunSpec-kompatibel", "vzlogger"]
+    },
+    "systems": {
+        "name": "systems",
+        "values": ["E3DC", "Fronius", "Huawei", "Kaco", "KOSTAL", "LG ESS", "RCT Power", "SENEC.Home", "SMA", "SolarEdge", "sonnen", "SunSpec-kompatibel", "Tesla PowerWall", "VARTA Energiespeicher"]
+    },
+    "vehicles": {
+        "name": "vehicles",
+        "values": ["Audi", "BMW", "Citroën", "DS Automobiles", "Fiat", "Ford", "Hyundai", "Kia", "Mini", "Nissan", "NIU (E-Scooter)", "Opel", "OVMS", "Peugeot", "Porsche", "Renault", "Seat", "ŠKODA", "Tesla", "Tronity", "Volkswagen", "Volvo"]
+    }
+}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -41,6 +41,7 @@
       height="354"
       src="/img/evcc-hero.svg"
       alt="Elektroauto lädt Solarstrom an einer Wallbox. Person verwendet evcc auf dem Smartphone."
+      draggable="false"
     />
   </div>
 </header>

--- a/layouts/shortcodes/full_width_image.html
+++ b/layouts/shortcodes/full_width_image.html
@@ -1,3 +1,3 @@
 {{- $width := .Get "width" -}}
 {{- $height := .Get "height" -}}
-<img class="image--full" {{ with .Get "src" }}src="{{ . }}"{{ end }} {{ with .Get "alt" }}alt="{{ . }}"{{ end }} width="{{$width}}" height="{{$height}}" />
+<img class="image--full" {{ with .Get "src" }}src="{{ . }}"{{ end }} {{ with .Get "alt" }}alt="{{ . }}"{{ end }} width="{{$width}}" height="{{$height}}" draggable="false"/>

--- a/layouts/shortcodes/infobox-content.html
+++ b/layouts/shortcodes/infobox-content.html
@@ -1,0 +1,8 @@
+{{ $group := .Get "group" }}
+<p class="products group-{{$group}}">
+    {{ range .Site.Data.products }}
+        {{ if eq .name $group }}
+            {{ delimit .values " • " }}
+        {{ end }}
+    {{ end }}
+</p>

--- a/layouts/shortcodes/infobox-entry.html
+++ b/layouts/shortcodes/infobox-entry.html
@@ -1,7 +1,7 @@
 {{- $title := .Get "title" -}}
 {{- $img := .Get "img" -}}
 <div class="infobox_entry">
-  <img src="{{$img}}" alt="{{$title}}" width="140" height="140" />
+  <img src="{{$img}}" alt="{{$title}}" width="140" height="140" draggable="false" />
   <h3>{{$title}}</h3>
   {{ .Inner }}
 </div>

--- a/layouts/shortcodes/infobox-entry.html
+++ b/layouts/shortcodes/infobox-entry.html
@@ -3,5 +3,5 @@
 <div class="infobox_entry">
   <img src="{{$img}}" alt="{{$title}}" width="140" height="140" />
   <h3>{{$title}}</h3>
-  {{ .Inner | markdownify }}
+  {{ .Inner }}
 </div>


### PR DESCRIPTION
Moin (ich schreib mal weiter auf Englisch :)), 

I did a few major and minor tweaks to the page. Below I will list what I changed.

1. **"Backend" Improvement** [`8dbc426`](https://github.com/evcc-io/evcc.io/commit/8dbc4269158e7891bc55c505c275e59fe7383cb9) - New supported products and their order can now be easily edited with a new JSON file in `/data/products.json`. The JSON file is split up into the previous sections (the chargers had to be split into wallboxes and smart plugs) and thereby adds better editing experience. The dots separating the entries are implemented as well.
2. [`f4b01c5`](https://github.com/evcc-io/evcc.io/commit/f4b01c5b048b0984fe6c4eb4a224877f3b32ae0f) - The evcc-scheme image was previously not fitted in very well into the overall design. On mobile this stays the same, but on bigger screens it gets the same border-radius and width of the card in green below showing the supported and proved-to-be-working products. 
3. [`d523ad3`](https://github.com/evcc-io/evcc.io/commit/d523ad3d78d82f8944ae106bb426c70957bda2ce) - I thought it was important to make the wallbox, meter, inverter and Tesla icons undraggable. I also figured out it would be good to also change the hero-header-image and the EVCC scheme to be undraggable.
4. Lastly, [`160787a`](https://github.com/evcc-io/evcc.io/commit/160787af26621e4c2907ce2b57fd26e4bfe09983) - The screenshot-container is kind of too wide on desktop, so I changed that, too. It's now only 95% of the total width with a little space to the left and right. On mobile it's still full-width.

I hope you will approve those changes :)