### PR TITLE
Elli (Volkswagen) in overview

### DIFF
--- a/data/brands.json
+++ b/data/brands.json
@@ -14,7 +14,7 @@
   "Easee",
   "Ebee",
   "echarge",
-  "Elli",
+  "Elli (Volkswagen)",
   "EM2GO",
   "Ensto",
   "Etrel",


### PR DESCRIPTION
My suggestion: when I first read about the project and had a glimpse on the overview I did not recognise the Volkswagen Wallbox in your list of supported devices. I propose to say "Elli (Volkswagen)" there in the Overview.

Thx for this nice project and your work. It works like a charm on my site with Elli (Volkswagen) ID. Charger Pro + Sungrow SH8. I use 1-phase loading with 6-16 Ampere. The configuration dialog on the commandline is comfortable. With your fresh release yesterday v0.116.6 also the connect status is fixed and works. Thanks for all that.