### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,6 +12,8 @@ on:
     - cron: 0 5 * * 0-6
 jobs:
   deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/evcc-io/evcc.io/security/code-scanning/3](https://github.com/evcc-io/evcc.io/security/code-scanning/3)

To fix the problem, we should add an explicit `permissions` block at the root of the workflow (or at the job level), restricting permissions to the least privilege required. In most workflows using GitHub Actions for deployment, only the deploy step actually requires `contents: write` access, while the rest need no special permissions. As there is a single job (`deploy`), it's simplest to set `permissions` for this job. This can be minimally set to `contents: write`, as the deploy action needs to push generated files to GitHub Pages. Other permissions can be omitted unless required. 

Concrete steps:
- Add the following block under `jobs > deploy`:
  ```yaml
  permissions:
    contents: write
  ```
- Place it as the first key below the job name (before `runs-on`) for clarity.

No new methods or imports are needed. No other changes outside this region are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
