### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sponsorkit.yaml
+++ b/.github/workflows/sponsorkit.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   update-sponsors:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Potential fix for [https://github.com/evcc-io/evcc.io/security/code-scanning/1](https://github.com/evcc-io/evcc.io/security/code-scanning/1)

The fix is to add an explicit `permissions` block to the affected job. The permissions should be set according to the needs of the job, and minimally granted. In this workflow, the critical action requiring write access is the `add-and-commit` step (which interacts with the repository contents for commits). Thus, the correct fix is to add a `permissions` block to the `update-sponsors` job and set `contents: write`. For maximum security, if possible, the permission could be further restricted to only steps requiring it, but GitHub Actions only supports setting job-wide permissions in vanilla workflow YAML. The block should be placed directly within the job definition, right after `runs-on`, before `steps`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
